### PR TITLE
Pipeline

### DIFF
--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/ArgumentScanner.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/ArgumentScanner.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.regex.Pattern;
+
+/**
+ * Parses text blocks containing pipeline arguments.
+ *
+ * @author Scott Shaffer
+ */
+public class ArgumentScanner {
+    /**
+     * The delimiter used to separate pipeline arguments.
+     */
+    public static final char ARGUMENT_SEPARATOR = ',';
+
+    // Zero or more white-space characters...
+    private static final String WHITE_SPACE = "\\s*";
+
+    // Argument separator surrounded by ignorable white space...
+    private static final Pattern ARGUMENT_PATTERN = Pattern.compile(WHITE_SPACE + ARGUMENT_SEPARATOR + WHITE_SPACE);
+
+    // Dates presented in the standard YYYY-MM-DD format...
+    private static final Pattern LOCAL_DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
+    /**
+     * The default argument scanner, which recognizes arguments of type
+     * boolean, int, double, String, and LocalDate (YYYY-MM-DD).
+     */
+    public static final ArgumentScanner DEFAULT = new ArgumentScanner();
+
+    /**
+     * Scans a text block for pipeline arguments and creates their object
+     * representations.
+     *
+     * @param text a text block to scan.
+     *
+     * @return the arguments encoded in the text block, with any primitive
+     * types boxed as their Object counterparts.
+     */
+    public Object[] scan(String text) {
+        List<Object> args = new ArrayList<>();
+        Scanner scanner = new Scanner(text).useDelimiter(ARGUMENT_PATTERN);
+
+        while (scanner.hasNext())
+            args.add(getNext(scanner));
+
+        return args.toArray();
+    }
+
+    /**
+     * Retrieves the next argument from the active scanner.
+     *
+     * @param scanner the active argument scanner.
+     *
+     * @return the next argument from the given scanner.
+     */
+    protected Object getNext(Scanner scanner) {
+        if (scanner.hasNextBoolean())
+            return scanner.nextBoolean();
+
+        if (scanner.hasNextInt())
+            return scanner.nextInt();
+
+        if (scanner.hasNextDouble())
+            return scanner.nextDouble();
+
+        return convert(scanner.next());
+    }
+
+    /**
+     * Converts a string that encodes another object (a LocalDate, for
+     * example, but not a primitive type) into that object, or simply
+     * returns the string if there is no other object encoded.
+     *
+     * @param s the argument string to convert.
+     *
+     * @return the object encoded by the given string, or the string itself
+     * if no other object is encoded.
+     */
+    protected Object convert(String s) {
+        if (LOCAL_DATE_PATTERN.matcher(s).matches())
+            return LocalDate.parse(s);
+        else
+            return s;
+    }
+}

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/CompositePipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/CompositePipeline.java
@@ -69,12 +69,12 @@ public class CompositePipeline implements DataPipeline {
     }
 
     @Override
-    public boolean isLengthPreserving() {
-        return pipelines.stream().allMatch(DataPipeline::isLengthPreserving);
+    public boolean isLocal() {
+        return pipelines.stream().allMatch(DataPipeline::isLocal);
     }
 
     @Override
-    public boolean isLocal() {
-        return pipelines.stream().allMatch(DataPipeline::isLocal);
+    public boolean isSizePreserving() {
+        return pipelines.stream().allMatch(DataPipeline::isSizePreserving);
     }
 }

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/CompositePipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/CompositePipeline.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.d3x.morpheus.vector.DataVector;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Collects a sequence of pipelines into a single pipeline.
+ *
+ * @author Scott Shaffer
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompositePipeline implements DataPipeline {
+    /**
+     * The pipelines to apply, in the order of application.
+     */
+    @Getter @NonNull
+    private final List<DataPipeline> pipelines;
+
+    /**
+     * Creates a composite pipeline from a series of individual pipelines.
+     *
+     * @param pipelines the pipelines to compose the composite.
+     *
+     * @return the composite of the specified pipelines.
+     */
+    public static CompositePipeline of(DataPipeline... pipelines) {
+        return new CompositePipeline(List.of(pipelines));
+    }
+
+    /**
+     * Creates a composite pipeline from a series of individual pipelines.
+     *
+     * @param pipelines the pipelines to compose the composite.
+     *
+     * @return the composite of the specified pipelines.
+     */
+    public static CompositePipeline of(Collection<DataPipeline> pipelines) {
+        return new CompositePipeline(List.copyOf(pipelines));
+    }
+
+    @Override
+    public <K> DataVector<K> apply(DataVector<K> vector) {
+        for (DataPipeline pipeline : pipelines)
+            pipeline.apply(vector);
+
+        return vector;
+    }
+
+    @Override
+    public boolean isLengthPreserving() {
+        return pipelines.stream().allMatch(DataPipeline::isLengthPreserving);
+    }
+
+    @Override
+    public boolean isLocal() {
+        return pipelines.stream().allMatch(DataPipeline::isLocal);
+    }
+}

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -61,14 +61,6 @@ public interface DataPipeline {
     }
 
     /**
-     * Identifies transformations that do not add or remove elements
-     * from the input vector.
-     *
-     * @return {@code true} iff this is a length-preserving pipeline.
-     */
-    boolean isLengthPreserving();
-
-    /**
      * Identifies <em>local</em> transformations: the result of an
      * element transformation depends only on the initial value of
      * that element and is independent of all other element values.
@@ -78,13 +70,21 @@ public interface DataPipeline {
     boolean isLocal();
 
     /**
-     * A local, length-preserving pipeline that replaces each element
+     * Identifies transformations that do not add or remove elements
+     * from the input vector.
+     *
+     * @return {@code true} iff this is a size-preserving pipeline.
+     */
+    boolean isSizePreserving();
+
+    /**
+     * A local, size-preserving pipeline that replaces each element
      * with its absolute value.
      */
     DataPipeline abs = local(Math::abs);
 
     /**
-     * A non-local, length-preserving pipeline that subtracts the mean
+     * A non-local, size-preserving pipeline that subtracts the mean
      * from each element in the DataVector, resulting in a transformed
      * vector with zero mean.
      */
@@ -96,7 +96,7 @@ public interface DataPipeline {
         }
 
         @Override
-        public boolean isLengthPreserving() {
+        public boolean isSizePreserving() {
             return true;
         }
 
@@ -107,13 +107,13 @@ public interface DataPipeline {
     };
 
     /**
-     * A local, length-preserving pipeline that applies the exponential function
+     * A local, size-preserving pipeline that applies the exponential function
      * to each element.
      */
     DataPipeline exp = local(Math::exp);
 
     /**
-     * A local, length-preserving pipeline that flips the sign of each element.
+     * A local, size-preserving pipeline that flips the sign of each element.
      */
     DataPipeline flip = local(value -> -value);
 
@@ -123,19 +123,19 @@ public interface DataPipeline {
     DataPipeline identity = local(DoubleUnaryOperator.identity());
 
     /**
-     * A local, length-preserving pipeline that replaces each element
+     * A local, size-preserving pipeline that replaces each element
      * with its reciprocal.
      */
     DataPipeline invert = local(x -> 1.0 / x);
 
     /**
-     * A local, length-preserving pipeline that replaces each element
+     * A local, size-preserving pipeline that replaces each element
      * with its natural logarithm.
      */
     DataPipeline log = local(Math::log);
 
     /**
-     * A non-local, length-preserving pipeline that rescales the vector
+     * A non-local, size-preserving pipeline that rescales the vector
      * into a normalized unit vector.
      */
     DataPipeline normalize = new DataPipeline() {
@@ -145,7 +145,7 @@ public interface DataPipeline {
         }
 
         @Override
-        public boolean isLengthPreserving() {
+        public boolean isSizePreserving() {
             return true;
         }
 
@@ -156,7 +156,7 @@ public interface DataPipeline {
     };
 
     /**
-     * A local, length-preserving pipeline that replaces each element
+     * A local, size-preserving pipeline that replaces each element
      * with its sign: {@code -1.0} if the element is negative (by an
      * amount greater than the default DoubleComparator tolerance),
      * {@code +1.0} if the element is positive (by an amount greater
@@ -166,18 +166,18 @@ public interface DataPipeline {
     DataPipeline sign = local(DoubleComparator.DEFAULT::sign);
 
     /**
-     * A local, length-preserving pipeline that replaces each element
+     * A local, size-preserving pipeline that replaces each element
      * with its square root.
      */
     DataPipeline sqrt = local(Math::sqrt);
 
     /**
-     * A local, length-preserving pipeline that squares each element.
+     * A local, size-preserving pipeline that squares each element.
      */
     DataPipeline square = local(x -> x * x);
 
     /**
-     * A non-local, length-preserving pipeline that subtracts the mean
+     * A non-local, size-preserving pipeline that subtracts the mean
      * from each element in the DataVector and divides each element by
      * the standard deviation, resulting in a transformed vector with
      * zero mean and unit variance.
@@ -190,7 +190,7 @@ public interface DataPipeline {
         }
 
         @Override
-        public boolean isLengthPreserving() {
+        public boolean isSizePreserving() {
             return true;
         }
 
@@ -201,12 +201,12 @@ public interface DataPipeline {
     };
 
     /**
-     * Returns a local, length-preserving pipeline that adds a constant
+     * Returns a local, size-preserving pipeline that adds a constant
      * value to each element.
      *
      * @param addend the constant value to add to each element.
      *
-     * @return a local, length-preserving pipeline that adds the given
+     * @return a local, size-preserving pipeline that adds the given
      * value to each element.
      */
     static DataPipeline add(double addend) {
@@ -214,7 +214,7 @@ public interface DataPipeline {
     }
 
     /**
-     * Returns a local, length-preserving pipeline that bounds each element
+     * Returns a local, size-preserving pipeline that bounds each element
      * on a fixed interval.
      *
      * @param lower the lower bound of the interval.
@@ -257,12 +257,12 @@ public interface DataPipeline {
     }
 
     /**
-     * Returns a local, length-preserving pipeline that divides each
+     * Returns a local, size-preserving pipeline that divides each
      * element by a constant factor.
      *
      * @param factor the constant factor to divide each element.
      *
-     * @return a local, length-preserving pipeline that divides each
+     * @return a local, size-preserving pipeline that divides each
      * element by the given factor.
      */
     static DataPipeline divide(double factor) {
@@ -270,9 +270,9 @@ public interface DataPipeline {
     }
 
     /**
-     * Creates a new non-local, length-preserving pipeline that rescales
-     * the elements of a vector to a target <em>leverage</em>: the sum of
-     * the absolute values in the vector.
+     * Creates a new non-local, size-preserving pipeline that rescales
+     * the elements of a vector to a target <em>leverage</em>: the sum
+     * of the absolute values in the vector.
      *
      * @param target the target leverage.
      *
@@ -296,7 +296,7 @@ public interface DataPipeline {
             }
 
             @Override
-            public boolean isLengthPreserving() {
+            public boolean isSizePreserving() {
                 return true;
             }
 
@@ -308,23 +308,23 @@ public interface DataPipeline {
     }
 
     /**
-     * Creates a new local, length-preserving pipeline for a given operator.
+     * Creates a new local, size-preserving pipeline for a given operator.
      *
      * @param operator the unary function that transforms the element values.
      *
-     * @return a new local, length-preserving pipeline with the given operator.
+     * @return a new local, size-preserving pipeline with the given operator.
      */
     static DataPipeline local(DoubleUnaryOperator operator) {
         return LocalPipeline.of(operator);
     }
 
     /**
-     * Returns a local, length-preserving pipeline that multiplies each
+     * Returns a local, size-preserving pipeline that multiplies each
      * element by a constant factor.
      *
      * @param factor the constant factor to multiply each element.
      *
-     * @return a local, length-preserving pipeline that multiplies each
+     * @return a local, size-preserving pipeline that multiplies each
      * element by the given factor.
      */
     static DataPipeline multiply(double factor) {
@@ -332,12 +332,12 @@ public interface DataPipeline {
     }
 
     /**
-     * Returns a local, length-preserving pipeline that raises each element
+     * Returns a local, size-preserving pipeline that raises each element
      * to a power.
      *
      * @param exponent the exponent of the power function.
      *
-     * @return a local, length-preserving pipeline that raises each element
+     * @return a local, size-preserving pipeline that raises each element
      * to the specified power.
      */
     static DataPipeline pow(double exponent) {
@@ -345,12 +345,12 @@ public interface DataPipeline {
     }
 
     /**
-     * Returns a local, length-preserving pipeline that replaces missing
+     * Returns a local, size-preserving pipeline that replaces missing
      * ({@code Double.NaN}) values with a fixed value.
      *
      * @param replacement the value to assign missing elements.
      *
-     * @return a local, length-preserving pipeline that replaces missing
+     * @return a local, size-preserving pipeline that replaces missing
      * values with the specified replacement.
      */
     static DataPipeline replaceNaN(double replacement) {
@@ -358,12 +358,12 @@ public interface DataPipeline {
     }
 
     /**
-     * Returns a local, length-preserving pipeline that subtracts a
-     * constant value from each element.
+     * Returns a local, size-preserving pipeline that subtracts a constant
+     * value from each element.
      *
      * @param subtrahend the constant value to subtract from each element.
      *
-     * @return a local, length-preserving pipeline that subtracts the
+     * @return a local, size-preserving pipeline that subtracts the
      * given value from each element.
      */
     static DataPipeline subtract(double subtrahend) {
@@ -371,7 +371,7 @@ public interface DataPipeline {
     }
 
     /**
-     * Returns a non-local, length-preserving pipeline that pulls outliers
+     * Returns a non-local, size-preserving pipeline that pulls outliers
      * into a location defined by a quantile value.  With a quantile value
      * of {@code 0.05}, for example, elements below the 5th percentile will
      * be raised to the 5th percentile and those above the 95th percentile
@@ -408,7 +408,7 @@ public interface DataPipeline {
             }
 
             @Override
-            public boolean isLengthPreserving() {
+            public boolean isSizePreserving() {
                 return true;
             }
 

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -165,7 +165,6 @@ public interface DataPipeline {
         @Override
         public <K> DataVector<K> apply(DataVector<K> vector) {
             double sdev = new StdDev(true).compute(vector);
-
             return composite(demean, divide(sdev)).apply(vector);
         }
 

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -54,8 +54,7 @@ public interface DataPipeline {
      * @param keyClass   the runtime class for the keys.
      * @param vectorView the vector view to transform.
      *
-     * @return the input vector, as modified by this pipeline, for
-     * operator chaining.
+     * @return the transformed vector.
      */
     default <K> DoubleSeries<K> apply(Class<K> keyClass, DataVectorView<K> vectorView) {
         return DoubleSeries.copyOf(keyClass, apply(DataVector.copy(vectorView)));

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -108,6 +108,12 @@ public interface DataPipeline {
     };
 
     /**
+     * A local, length-preserving pipeline that applies the exponential function
+     * to each element.
+     */
+    DataPipeline exp = local(Math::exp);
+
+    /**
      * A local, length-preserving pipeline that flips the sign of each element.
      */
     DataPipeline flip = local(value -> -value);
@@ -116,6 +122,12 @@ public interface DataPipeline {
      * The identity pipeline: all elements are unchanged.
      */
     DataPipeline identity = local(DoubleUnaryOperator.identity());
+
+    /**
+     * A local, length-preserving pipeline that replaces each element
+     * with its reciprocal.
+     */
+    DataPipeline invert = local(x -> 1.0 / x);
 
     /**
      * A local, length-preserving pipeline that replaces each element
@@ -138,6 +150,11 @@ public interface DataPipeline {
      * with its square root.
      */
     DataPipeline sqrt = local(Math::sqrt);
+
+    /**
+     * A local, length-preserving pipeline that squares each element.
+     */
+    DataPipeline square = local(x -> x * x);
 
     /**
      * A non-local, length-preserving pipeline that subtracts the mean
@@ -255,6 +272,19 @@ public interface DataPipeline {
      */
     static DataPipeline multiply(double factor) {
         return local(element -> element * factor);
+    }
+
+    /**
+     * Returns a local, length-preserving pipeline that raises each element
+     * to a power.
+     *
+     * @param exponent the exponent of the power function.
+     *
+     * @return a local, length-preserving pipeline that raises each element
+     * to the specified power.
+     */
+    static DataPipeline pow(double exponent) {
+        return local(element -> Math.pow(element, exponent));
     }
 
     /**

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -196,7 +196,28 @@ public interface DataPipeline {
     /**
      * The identity pipeline: all elements are unchanged.
      */
-    DataPipeline identity = local("identity()", DoubleUnaryOperator.identity());
+    DataPipeline identity = new DataPipeline() {
+        @Override
+        public <K> DataVector<K> apply(DataVector<K> vector) {
+            // Do nothing...
+            return vector;
+        }
+
+        @Override
+        public String encode() {
+            return "identity()";
+        }
+
+        @Override
+        public boolean isLocal() {
+            return true;
+        }
+
+        @Override
+        public boolean isSizePreserving() {
+            return true;
+        }
+    };
 
     /**
      * A local, size-preserving pipeline that replaces each element

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -230,7 +230,7 @@ public interface DataPipeline {
      * element by the given factor.
      */
     static DataPipeline divide(double factor) {
-        return local(element -> element / factor);
+        return multiply(1.0 / factor);
     }
 
     /**
@@ -280,7 +280,7 @@ public interface DataPipeline {
      * given value from each element.
      */
     static DataPipeline subtract(double subtrahend) {
-        return local(element -> element - subtrahend);
+        return add(-subtrahend);
     }
 
     /**

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import java.util.Collection;
+import java.util.function.DoubleUnaryOperator;
+
+import com.d3x.morpheus.series.DoubleSeries;
+import com.d3x.morpheus.stats.Mean;
+import com.d3x.morpheus.stats.Percentile;
+import com.d3x.morpheus.stats.StdDev;
+import com.d3x.morpheus.util.DoubleComparator;
+import com.d3x.morpheus.util.MorpheusException;
+import com.d3x.morpheus.vector.DataVector;
+import com.d3x.morpheus.vector.DataVectorView;
+
+/**
+ * Defines an in-place transformation of a DataVector.
+ *
+ * @author Scott Shaffer
+ */
+public interface DataPipeline {
+    /**
+     * Applies the transformation defined by this pipeline to a data
+     * vector; the vector is modified in place.
+     *
+     * @param <K>    the runtime type for the DataVector keys.
+     * @param vector the vector to transform.
+     *
+     * @return the input vector, as modified by this pipeline, for
+     * operator chaining.
+     */
+    <K> DataVector<K> apply(DataVector<K> vector);
+
+    /**
+     * Creates a copy of a vector view, applies the transformation defined
+     * by this pipeline to the copy, and returns the transformed vector in
+     * a new DoubleSeries.
+     *
+     * @param <K>        the runtime type for the keys.
+     * @param keyClass   the runtime class for the keys.
+     * @param vectorView the vector view to transform.
+     *
+     * @return the input vector, as modified by this pipeline, for
+     * operator chaining.
+     */
+    default <K> DoubleSeries<K> apply(Class<K> keyClass, DataVectorView<K> vectorView) {
+        return DoubleSeries.copyOf(keyClass, apply(DataVector.copy(vectorView)));
+    }
+
+    /**
+     * Identifies transformations that do not add or remove elements
+     * from the input vector.
+     *
+     * @return {@code true} iff this is a length-preserving pipeline.
+     */
+    boolean isLengthPreserving();
+
+    /**
+     * Identifies <em>local</em> transformations: the result of an
+     * element transformation depends only on the initial value of
+     * that element and is independent of all other element values.
+     *
+     * @return {@code true} iff this is a local pipeline.
+     */
+    boolean isLocal();
+
+    /**
+     * A local, length-preserving pipeline that replaces each element
+     * with its absolute value.
+     */
+    DataPipeline abs = local(Math::abs);
+
+    /**
+     * A non-local, length-preserving pipeline that subtracts the mean
+     * from each element in the DataVector, resulting in a transformed
+     * vector with zero mean.
+     */
+    DataPipeline demean = new DataPipeline() {
+        @Override
+        public <K> DataVector<K> apply(DataVector<K> vector) {
+            double mean = new Mean().compute(vector);
+            return subtract(mean).apply(vector);
+        }
+
+        @Override
+        public boolean isLengthPreserving() {
+            return true;
+        }
+
+        @Override
+        public boolean isLocal() {
+            return false;
+        }
+    };
+
+    /**
+     * A local, length-preserving pipeline that flips the sign of each element.
+     */
+    DataPipeline flip = local(value -> -value);
+
+    /**
+     * The identity pipeline: all elements are unchanged.
+     */
+    DataPipeline identity = local(DoubleUnaryOperator.identity());
+
+    /**
+     * A local, length-preserving pipeline that replaces each element
+     * with its natural logarithm.
+     */
+    DataPipeline log = local(Math::log);
+
+    /**
+     * A local, length-preserving pipeline that replaces each element
+     * with its sign: {@code -1.0} if the element is negative (by an
+     * amount greater than the default DoubleComparator tolerance),
+     * {@code +1.0} if the element is positive (by an amount greater
+     * than the default tolerance), or {@code 0.0} if the element is
+     * equal to zero (within the default tolerance.
+     */
+    DataPipeline sign = local(DoubleComparator.DEFAULT::sign);
+
+    /**
+     * A local, length-preserving pipeline that replaces each element
+     * with its square root.
+     */
+    DataPipeline sqrt = local(Math::sqrt);
+
+    /**
+     * A non-local, length-preserving pipeline that subtracts the mean
+     * from each element in the DataVector and divides each element by
+     * the standard deviation, resulting in a transformed vector with
+     * zero mean and unit variance.
+     */
+    DataPipeline standardize = new DataPipeline() {
+        @Override
+        public <K> DataVector<K> apply(DataVector<K> vector) {
+            double sdev = new StdDev(true).compute(vector);
+
+            return composite(demean, divide(sdev)).apply(vector);
+        }
+
+        @Override
+        public boolean isLengthPreserving() {
+            return true;
+        }
+
+        @Override
+        public boolean isLocal() {
+            return false;
+        }
+    };
+
+    /**
+     * Returns a local, length-preserving pipeline that adds a constant
+     * value to each element.
+     *
+     * @param addend the constant value to add to each element.
+     *
+     * @return a local, length-preserving pipeline that adds the given
+     * value to each element.
+     */
+    static DataPipeline add(double addend) {
+        return local(element -> element + addend);
+    }
+
+    /**
+     * Returns a local, length-preserving pipeline that bounds each element
+     * on a fixed interval.
+     *
+     * @param lower the lower bound of the interval.
+     * @param upper the upper bound of the interval.
+     *
+     * @return a bounding pipeline with the specified interval.
+     *
+     * @throws RuntimeException unless the interval is valid (the lower bound
+     * is less than or equal to the upper bound).
+     */
+    static DataPipeline bound(double lower, double upper) {
+        if (lower > upper)
+            throw new MorpheusException("Invalid bounding interval: [%f, %f].", lower, upper);
+        else
+            return local(element -> Math.max(lower, Math.min(upper, element)));
+    }
+
+    /**
+     * Returns a composite pipeline composed of a series of individual
+     * pipelines.
+     *
+     * @param pipelines the pipelines to compose the composite.
+     *
+     * @return the composite of the specified pipelines.
+     */
+    static DataPipeline composite(DataPipeline... pipelines) {
+        return CompositePipeline.of(pipelines);
+    }
+
+    /**
+     * Returns a composite pipeline composed of a series of individual
+     * pipelines.
+     *
+     * @param pipelines the pipelines to compose the composite.
+     *
+     * @return the composite of the specified pipelines.
+     */
+    static DataPipeline composite(Collection<DataPipeline> pipelines) {
+        return CompositePipeline.of(pipelines);
+    }
+
+    /**
+     * Returns a local, length-preserving pipeline that divides each
+     * element by a constant factor.
+     *
+     * @param factor the constant factor to divide each element.
+     *
+     * @return a local, length-preserving pipeline that divides each
+     * element by the given factor.
+     */
+    static DataPipeline divide(double factor) {
+        return local(element -> element / factor);
+    }
+
+    /**
+     * Creates a new local, length-preserving pipeline for a given operator.
+     *
+     * @param operator the unary function that transforms the element values.
+     *
+     * @return a new local, length-preserving pipeline with the given operator.
+     */
+    static DataPipeline local(DoubleUnaryOperator operator) {
+        return LocalPipeline.of(operator);
+    }
+
+    /**
+     * Returns a local, length-preserving pipeline that multiplies each
+     * element by a constant factor.
+     *
+     * @param factor the constant factor to multiply each element.
+     *
+     * @return a local, length-preserving pipeline that multiplies each
+     * element by the given factor.
+     */
+    static DataPipeline multiply(double factor) {
+        return local(element -> element * factor);
+    }
+
+    /**
+     * Returns a local, length-preserving pipeline that replaces missing
+     * ({@code Double.NaN}) values with a fixed value.
+     *
+     * @param replacement the value to assign missing elements.
+     *
+     * @return a local, length-preserving pipeline that replaces missing
+     * values with the specified replacement.
+     */
+    static DataPipeline replaceNaN(double replacement) {
+        return local(element -> Double.isNaN(element) ? replacement : element);
+    }
+
+    /**
+     * Returns a local, length-preserving pipeline that subtracts a
+     * constant value from each element.
+     *
+     * @param subtrahend the constant value to subtract from each element.
+     *
+     * @return a local, length-preserving pipeline that subtracts the
+     * given value from each element.
+     */
+    static DataPipeline subtract(double subtrahend) {
+        return local(element -> element - subtrahend);
+    }
+
+    /**
+     * Returns a non-local, length-preserving pipeline that pulls outliers
+     * into a location defined by a quantile value.  With a quantile value
+     * of {@code 0.05}, for example, elements below the 5th percentile will
+     * be raised to the 5th percentile and those above the 95th percentile
+     * will be lowered to the 95th percentile.
+     *
+     * @param quantile the (fractional) quantile value that defines the
+     *                 lower and upper bounds for the elements.
+     *
+     * @return a trimming pipeline for the specified quantile.
+     *
+     * @throws RuntimeException unless the quantile is within the valid range
+     * {@code [0.0, 0.5]}.
+     */
+    static DataPipeline trim(double quantile) {
+        DoubleComparator comparator = DoubleComparator.DEFAULT;
+
+        if (comparator.isNegative(quantile))
+            throw new MorpheusException("Quantile must be non-negative.");
+
+        if (comparator.isZero(quantile))
+            return identity;
+
+        if (comparator.compare(quantile, 0.5) > 0)
+            throw new MorpheusException("Quantile must not exceed one-half.");
+
+        return new DataPipeline() {
+            @Override
+            public <K> DataVector<K> apply(DataVector<K> vector) {
+                // Percentile takes fractional (quantile) values...
+                double lower = new Percentile(quantile).compute(vector);
+                double upper = new Percentile(1.0 - quantile).compute(vector);
+
+                return bound(lower, upper).apply(vector);
+            }
+
+            @Override
+            public boolean isLengthPreserving() {
+                return true;
+            }
+
+            @Override
+            public boolean isLocal() {
+                return false;
+            }
+        };
+    }
+}

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/DataPipeline.java
@@ -15,7 +15,7 @@
  */
 package com.d3x.morpheus.pipeline;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.function.DoubleUnaryOperator;
 
 import com.d3x.morpheus.frame.DataFrame;
@@ -350,7 +350,7 @@ public interface DataPipeline {
      * @return the composite of the specified pipelines.
      */
     static DataPipeline composite(DataPipeline... pipelines) {
-        return CompositePipeline.of(pipelines);
+        return composite(List.of(pipelines));
     }
 
     /**
@@ -359,10 +359,21 @@ public interface DataPipeline {
      *
      * @param pipelines the pipelines to compose the composite.
      *
-     * @return the composite of the specified pipelines.
+     * @return the composite of the specified pipelines (the identity
+     * pipeline, if the collection is empty; the single pipeline itself
+     * if the list contains only a single pipeline).
      */
-    static DataPipeline composite(Collection<DataPipeline> pipelines) {
-        return CompositePipeline.of(pipelines);
+    static DataPipeline composite(List<DataPipeline> pipelines) {
+        switch (pipelines.size()) {
+            case 0:
+                return identity;
+
+            case 1:
+                return pipelines.get(0);
+
+            default:
+                return CompositePipeline.of(pipelines);
+        }
     }
 
     /**

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/LocalPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/LocalPipeline.java
@@ -24,7 +24,7 @@ import lombok.Getter;
 import lombok.NonNull;
 
 /**
- * Implements local, length-preserving data pipelines.
+ * Implements local, size-preserving data pipelines.
  *
  * @author Scott Shaffer
  */
@@ -45,12 +45,12 @@ public final class LocalPipeline implements DataPipeline {
     }
 
     @Override
-    public boolean isLengthPreserving() {
+    public boolean isLocal() {
         return true;
     }
 
     @Override
-    public boolean isLocal() {
+    public boolean isSizePreserving() {
         return true;
     }
 }

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/LocalPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/LocalPipeline.java
@@ -31,6 +31,12 @@ import lombok.NonNull;
 @AllArgsConstructor(staticName = "of")
 public final class LocalPipeline implements DataPipeline {
     /**
+     * The string encoding for the pipeline.
+     */
+    @Getter @NonNull
+    private final String encoding;
+
+    /**
      * The local transformation applied to each element.
      */
     @Getter @NonNull
@@ -42,6 +48,11 @@ public final class LocalPipeline implements DataPipeline {
             vector.setElement(key, operator.applyAsDouble(vector.getElement(key)));
 
         return vector;
+    }
+
+    @Override
+    public String encode() {
+        return encoding;
     }
 
     @Override

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/LocalPipeline.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/LocalPipeline.java
@@ -30,6 +30,9 @@ import lombok.NonNull;
  */
 @AllArgsConstructor(staticName = "of")
 public final class LocalPipeline implements DataPipeline {
+    /**
+     * The local transformation applied to each element.
+     */
     @Getter @NonNull
     private final DoubleUnaryOperator operator;
 

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
@@ -87,6 +87,7 @@ public class PipelineFactory {
                 assertArgs(name, args, Number.class);
                 return DataPipeline.pow(doubleArg(args, 0));
 
+            case "replaceNA": // Fall-through
             case "replaceNaN":
                 assertArgs(name, args, Number.class);
                 return DataPipeline.replaceNaN(doubleArg(args, 0));

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import com.d3x.morpheus.util.MorpheusException;
+
+/**
+ * Creates pipelines from a name and argument string.
+ *
+ * @author Scott Shaffer
+ */
+public class PipelineFactory {
+    /**
+     * Creates a new pipeline given its name and argument(s).
+     *
+     * @param name the name of the pipeline.
+     * @param args the arguments required to create the pipeline.
+     *
+     * @return the pipeline with the specified name and argument(s).
+     */
+    public DataPipeline create(String name, Object... args) {
+        switch (name) {
+            case "abs":
+                assertNoArgs(name, args);
+                return DataPipeline.abs;
+
+            case "add":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.add(doubleArg(args, 0));
+
+            case "bound":
+                assertArgs(name, args, Number.class, Number.class);
+                return DataPipeline.bound(doubleArg(args, 0), doubleArg(args, 1));
+
+            case "demean":
+                assertNoArgs(name, args);
+                return DataPipeline.demean;
+
+            case "divide":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.divide(doubleArg(args, 0));
+
+            case "flip":
+                assertNoArgs(name, args);
+                return DataPipeline.flip;
+
+            case "identity":
+                assertNoArgs(name, args);
+                return DataPipeline.identity;
+
+            case "log":
+                assertNoArgs(name, args);
+                return DataPipeline.log;
+
+            case "multiply":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.multiply(doubleArg(args, 0));
+
+            case "replaceNaN":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.replaceNaN(doubleArg(args, 0));
+
+            case "sign":
+                assertNoArgs(name, args);
+                return DataPipeline.sign;
+
+            case "sqrt":
+                assertNoArgs(name, args);
+                return DataPipeline.sqrt;
+
+            case "standardize":
+                assertNoArgs(name, args);
+                return DataPipeline.standardize;
+
+            case "subtract":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.subtract(doubleArg(args, 0));
+
+            case "trim":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.trim(doubleArg(args, 0));
+
+            default:
+                throw new MorpheusException("Unknown pipeline: [%s].", name);
+        }
+    }
+
+    /**
+     * Ensures that the arguments that were supplied to this factory have
+     * the expected number and type.
+     *
+     * @param name  the name of the pipeline.
+     * @param args  the supplied arguments.
+     * @param types the expected argument types.
+     *
+     * @throws RuntimeException unless the number and type of the actual
+     * arguments match those that are expected.
+     */
+    protected void assertArgs(String name, Object[] args, Class<?>... types) {
+        if (args.length != types.length)
+            throw new MorpheusException("Expected [%d] arguments for pipeline [%s] but found [%d].", name, args.length, types.length);
+
+        for (int index = 0; index < args.length; ++index)
+            if (!types[index].isInstance(args[index]))
+                throw new MorpheusException("Expected class [%s] for argument [%d] of pipeline [%s] but found [%s].",
+                        types[index].getSimpleName(), index, name, args[index].getClass().getSimpleName());
+    }
+
+    /**
+     * Ensures that no arguments were specified when none are expected.
+     *
+     * @param name the name of the pipeline.
+     * @param args the supplied arguments.
+     *
+     * @throws RuntimeException unless the argument array is empty.
+     */
+    protected void assertNoArgs(String name, Object[] args) {
+        if (args.length > 0)
+            throw new MorpheusException("Pipeline [%s] takes no arguments.", name);
+    }
+
+    /**
+     * Returns a floating-point argument from an argument list.
+     *
+     * @param args the arguments supplied to this factory.
+     * @param index the (zero-offset) index of the desired argument.
+     *
+     * @return the floating-point argument at the specified position.
+     *
+     * @throws RuntimeException unless a numeric argument is present
+     * at the specified position.
+     */
+    protected double doubleArg(Object[] args, int index) {
+        return ((Number) args[index]).doubleValue();
+    }
+}

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
@@ -75,6 +75,10 @@ public class PipelineFactory {
                 assertNoArgs(name, args);
                 return DataPipeline.invert;
 
+            case "lever":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.lever(doubleArg(args, 0));
+
             case "log":
                 assertNoArgs(name, args);
                 return DataPipeline.log;
@@ -82,6 +86,10 @@ public class PipelineFactory {
             case "multiply":
                 assertArgs(name, args, Number.class);
                 return DataPipeline.multiply(doubleArg(args, 0));
+
+            case "normalize":
+                assertNoArgs(name, args);
+                return DataPipeline.normalize;
 
             case "pow":
                 assertArgs(name, args, Number.class);

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
@@ -24,6 +24,12 @@ import com.d3x.morpheus.util.MorpheusException;
  */
 public class PipelineFactory {
     /**
+     * The default pipeline factory, which recognizes all pipelines defined
+     * in the DataPipeline interface.
+     */
+    public static final PipelineFactory DEFAULT = new PipelineFactory();
+
+    /**
      * Creates a new pipeline given its name and argument(s).
      *
      * @param name the name of the pipeline.
@@ -53,6 +59,10 @@ public class PipelineFactory {
                 assertArgs(name, args, Number.class);
                 return DataPipeline.divide(doubleArg(args, 0));
 
+            case "exp":
+                assertNoArgs(name, args);
+                return DataPipeline.exp;
+
             case "flip":
                 assertNoArgs(name, args);
                 return DataPipeline.flip;
@@ -61,6 +71,10 @@ public class PipelineFactory {
                 assertNoArgs(name, args);
                 return DataPipeline.identity;
 
+            case "invert":
+                assertNoArgs(name, args);
+                return DataPipeline.invert;
+
             case "log":
                 assertNoArgs(name, args);
                 return DataPipeline.log;
@@ -68,6 +82,10 @@ public class PipelineFactory {
             case "multiply":
                 assertArgs(name, args, Number.class);
                 return DataPipeline.multiply(doubleArg(args, 0));
+
+            case "pow":
+                assertArgs(name, args, Number.class);
+                return DataPipeline.pow(doubleArg(args, 0));
 
             case "replaceNaN":
                 assertArgs(name, args, Number.class);
@@ -80,6 +98,10 @@ public class PipelineFactory {
             case "sqrt":
                 assertNoArgs(name, args);
                 return DataPipeline.sqrt;
+
+            case "square":
+                assertNoArgs(name, args);
+                return DataPipeline.square;
 
             case "standardize":
                 assertNoArgs(name, args);

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineFactory.java
@@ -142,7 +142,7 @@ public class PipelineFactory {
      */
     protected void assertArgs(String name, Object[] args, Class<?>... types) {
         if (args.length != types.length)
-            throw new MorpheusException("Expected [%d] arguments for pipeline [%s] but found [%d].", name, args.length, types.length);
+            throw new MorpheusException("Expected [%d] arguments for pipeline [%s] but found [%d].", types.length, name, args.length);
 
         for (int index = 0; index < args.length; ++index)
             if (!types[index].isInstance(args[index]))

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineScanner.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineScanner.java
@@ -128,10 +128,6 @@ public class PipelineScanner {
         if (matcher.groupCount() != 3)
             throw new MorpheusException("Malformed pipeline: [%s].", matcher.group());
 
-        //System.out.printf("1: [%s]%n", matcher.group(1));
-        //System.out.printf("2: [%s]%n", matcher.group(2));
-        //System.out.printf("3: [%s]%n", matcher.group(3));
-
         // For the first pipeline, only ignorable white space is permitted in the
         // group 1 text; for additional pipelines, the group 1 text must contain
         // the pipeline separator and may contain ignorable white space...

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineScanner.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/pipeline/PipelineScanner.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.d3x.morpheus.util.MorpheusException;
+
+/**
+ * Parses a string representation of a single or composite pipeline.
+ *
+ * @author Scott Shaffer
+ */
+public class PipelineScanner {
+    private final String source;
+    private final Matcher matcher;
+    private final PipelineFactory factory;
+    private final List<DataPipeline> pipelines = new ArrayList<>();
+
+    // Index of the character in the source string where the last
+    // match ended; used to ensure that only ignorable white-space
+    // remains after all pipelines are matched...
+    private int matchEnd;
+
+    private PipelineScanner(String source, PipelineFactory factory) {
+        this.source = source;
+        this.factory = factory;
+        this.matcher = PIPELINE_PATTERN.matcher(source);
+    }
+
+    /**
+     * The delimiter used to separate pipeline arguments.
+     */
+    public static final String ARGUMENT_SEPARATOR = ",";
+
+    /**
+     * The delimiter used to separate pipelines in a composite pipeline.
+     */
+    public static final String PIPELINE_SEPARATOR = ",";
+
+    private static final String START_GROUP = "(";  // Begin an indexed regex group
+    private static final String END_GROUP   = ")";  // End an indexed regex group
+
+    private static final String OPEN_PAREN  = "\\("; // Begin the pipeline argument(s)
+    private static final String CLOSE_PAREN = "\\)"; // End the pipeline argument(s)
+
+    private static final String FREE_TEXT   = ".*?";  // Any text, possibly empty (zero or more characters)...
+    private static final String SINGLE_WORD = "\\w+"; // A valid Java word having at least one character
+    private static final String WHITE_SPACE = "\\s*"; // Zero or more white-space characters...
+
+    // The delimiter and surrounding white space that will precede all pipelines except the first...
+    private static final String DELIM_GROUP = START_GROUP + FREE_TEXT + END_GROUP;
+
+    // The single Java word that specifies the pipeline name...
+    private static final String NAME_GROUP = START_GROUP + SINGLE_WORD + END_GROUP;
+
+    // The pipeline argument(s), enclosed in parentheses...
+    private static final String ARGS_GROUP = OPEN_PAREN + START_GROUP + FREE_TEXT + END_GROUP + CLOSE_PAREN;
+
+    private static final Pattern ARGUMENT_PATTERN = Pattern.compile(WHITE_SPACE + ARGUMENT_SEPARATOR + WHITE_SPACE);
+    private static final Pattern PIPELINE_PATTERN = Pattern.compile(DELIM_GROUP + NAME_GROUP + ARGS_GROUP);
+
+    /**
+     * Returns the single or composite pipeline encoded in a string.
+     *
+     * @param source  the string containing an encoded pipeline(s).
+     * @param factory a factory able to create the encoded pipeline(s).
+     *
+     * @return the single or composite pipeline encoded in the given
+     * source string.
+     *
+     * @throws RuntimeException unless the input string is properly
+     * formatted and the factory can create every encoded pipeline.
+     */
+    public static DataPipeline scan(String source, PipelineFactory factory) {
+        PipelineScanner scanner = new PipelineScanner(source, factory);
+        return scanner.scan();
+    }
+
+    private DataPipeline scan() {
+        while (matcher.find())
+            parsePipeline();
+
+        validateMatchEnd();
+        return resolvePipeline();
+    }
+
+    private void parsePipeline() {
+        validateMatch();
+        matchEnd = matcher.end();
+
+        String name = matcher.group(2);
+        Object[] args = parseArguments(matcher.group(3));
+
+        pipelines.add(factory.create(name, args));
+    }
+
+    private void validateMatch() {
+        if (matcher.groupCount() != 3)
+            throw new MorpheusException("Malformed pipeline: [%s].", matcher.group());
+
+        //System.out.printf("1: [%s]%n", matcher.group(1));
+        //System.out.printf("2: [%s]%n", matcher.group(2));
+        //System.out.printf("3: [%s]%n", matcher.group(3));
+
+        // For the first pipeline, only ignorable white space is permitted in the
+        // group 1 text; for additional pipelines, the group 1 text must contain
+        // the pipeline separator and may contain ignorable white space...
+        String group1 = matcher.group(1);
+        String content = group1.strip();
+
+        if (pipelines.isEmpty() && !content.isEmpty())
+            throw new MorpheusException("Invalid pipeline text: [%s].", group1);
+
+        if (!pipelines.isEmpty() && !content.equals(PIPELINE_SEPARATOR))
+            throw new MorpheusException("Invalid pipeline text: [%s].", group1);
+    }
+
+    private static Object[] parseArguments(String argString) {
+        List<Object> argList = new ArrayList<>();
+        Scanner scanner = new Scanner(argString).useDelimiter(ARGUMENT_PATTERN);
+
+        while (scanner.hasNext())
+            argList.add(getNext(scanner));
+
+        return argList.toArray();
+    }
+
+    private static Object getNext(Scanner scanner) {
+        if (scanner.hasNextBoolean())
+            return scanner.nextBoolean();
+
+        if (scanner.hasNextInt())
+            return scanner.nextInt();
+
+        if (scanner.hasNextDouble())
+            return scanner.nextDouble();
+
+        return scanner.next();
+    }
+
+    private void validateMatchEnd() {
+        // Only ignorable white space may remain unparsed after all
+        // pipelines have been matched...
+        String unparsed = source.substring(matchEnd);
+
+        if (!unparsed.strip().isEmpty())
+            throw new MorpheusException("Incomplete pipeline text: [%s].", unparsed);
+    }
+
+    private DataPipeline resolvePipeline() {
+        if (pipelines.isEmpty())
+            throw new MorpheusException("No pipelines encoded in source [%s].", source);
+        else if (pipelines.size() == 1)
+            return pipelines.get(0);
+        else
+            return DataPipeline.composite(pipelines);
+    }
+}

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/testng/NumericTestBase.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/testng/NumericTestBase.java
@@ -16,7 +16,6 @@
 package com.d3x.morpheus.testng;
 
 import com.d3x.morpheus.series.DoubleSeries;
-import com.d3x.morpheus.util.Asserts;
 import com.d3x.morpheus.util.DoubleComparator;
 
 import static org.testng.Assert.*;

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVector.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVector.java
@@ -15,6 +15,7 @@
  */
 package com.d3x.morpheus.vector;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -35,6 +36,34 @@ public interface DataVector<K> extends DataVectorView<K> {
      */
     default void setElement(DataVectorElement<K> element) {
         setElement(element.getKey(), element.getValue());
+    }
+
+    /**
+     * Assigns all elements from a collection.
+     *
+     * @param elements the elements to assign.
+     */
+    default void setElements(Collection<DataVectorElement<K>> elements) {
+        for (DataVectorElement<K> element : elements)
+            setElement(element);
+    }
+
+    /**
+     * Assigns all elements from a stream.
+     *
+     * @param elements the elements to assign.
+     */
+    default void setElements(Stream<DataVectorElement<K>> elements) {
+        elements.forEach(this::setElement);
+    }
+
+    /**
+     * Assigns all elements contained in another DataVector.
+     *
+     * @param vector the vector to assign.
+     */
+    default void setElements(DataVectorView<K> vector) {
+        setElements(vector.streamElements());
     }
 
     /**

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVector.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVector.java
@@ -17,6 +17,7 @@ package com.d3x.morpheus.vector;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public interface DataVector<K> extends DataVectorView<K> {
     /**
@@ -49,6 +50,19 @@ public interface DataVector<K> extends DataVectorView<K> {
         for (DataVectorElement<K> element : view.collectElements())
             vector.setElement(element);
 
+        return vector;
+    }
+
+    /**
+     * Collects the vector elements in a stream into a new DataVector.
+     *
+     * @param elements the elements to collect.
+     *
+     * @return a new DataVector containing the elements in the stream.
+     */
+    static <K> DataVector<K> collect(Stream<DataVectorElement<K>> elements) {
+        DataVector<K> vector = create();
+        elements.forEach(vector::setElement);
         return vector;
     }
 

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVector.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVector.java
@@ -15,6 +15,7 @@
  */
 package com.d3x.morpheus.vector;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public interface DataVector<K> extends DataVectorView<K> {
@@ -25,6 +26,42 @@ public interface DataVector<K> extends DataVectorView<K> {
      * @param value the value to assign.
      */
     void setElement(K key, double value);
+
+    /**
+     * Assigns a vector element.
+     *
+     * @param element the element to assign.
+     */
+    default void setElement(DataVectorElement<K> element) {
+        setElement(element.getKey(), element.getValue());
+    }
+
+    /**
+     * Creates a new data vector by copying the elements of an existing view.
+     *
+     * @param view the data vector view to copy.
+     *
+     * @return a new data vector with the same elements as the input view.
+     */
+    static <K> DataVector<K> copy(DataVectorView<K> view) {
+        DataVector<K> vector = create();
+
+        for (DataVectorElement<K> element : view.collectElements())
+            vector.setElement(element);
+
+        return vector;
+    }
+
+    /**
+     * Creates a new, empty data vector.
+     *
+     * @param <K> the runtime key type.
+     *
+     * @return a new, empty data vector with the desired key type.
+     */
+    static <K> DataVector<K> create() {
+        return new MapDataVector<>(new HashMap<>());
+    }
 
     /**
      * Returns a DataVector backed by a Double map; changes to the map

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVectorElement.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVectorElement.java
@@ -18,25 +18,33 @@ package com.d3x.morpheus.vector;
 import com.d3x.morpheus.util.DoubleComparator;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NonNull;
+import lombok.Value;
 
 /**
  * An immutable element in a DataVectorView.
  */
+@Value
 @AllArgsConstructor(staticName = "of")
-public final class DataVectorElement<K> {
+public class DataVectorElement<K> {
     /**
      * The key of this vector element.
      */
-    @Getter @NonNull
-    private final K key;
+    @NonNull K key;
 
     /**
      * The value in this vector element.
      */
-    @Getter
-    private final double value;
+    double value;
+
+    /**
+     * Identifies elements with non-missing values.
+     *
+     * @return {@code true} unless the value of this element is {@code Double.NaN}.
+     */
+    public boolean isSet() {
+        return !Double.isNaN(value);
+    }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVectorView.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVectorView.java
@@ -26,6 +26,7 @@ import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
 import com.d3x.morpheus.series.DoubleSeries;
+import com.d3x.morpheus.stats.SumSquares;
 import com.d3x.morpheus.util.DoubleComparator;
 import com.d3x.morpheus.util.MorpheusException;
 
@@ -291,6 +292,23 @@ public interface DataVectorView<K> {
      */
     default double innerProduct(DataVectorView<K> operand, DataVectorView<K> weights) {
         return InnerProduct.compute(this, operand, weights);
+    }
+
+    /**
+     * Computes the 1-norm of this data vector: the sum of the absolute
+     * values of each element.
+     * @return the 1-norm of this data vector.
+     */
+    default double norm1() {
+        return streamValues().filter(x -> !Double.isNaN(x)).map(Math::abs).sum();
+    }
+
+    /**
+     * Computes the 2-norm (Euclidean norm) of this data vector.
+     * @return the 2-norm (Euclidean norm) of this data vector.
+     */
+    default double norm2() {
+        return Math.sqrt(new SumSquares().compute(this));
     }
 
     /**

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVectorView.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/DataVectorView.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
+import com.d3x.morpheus.series.DoubleSeries;
 import com.d3x.morpheus.util.DoubleComparator;
 import com.d3x.morpheus.util.MorpheusException;
 
@@ -337,5 +338,18 @@ public interface DataVectorView<K> {
      */
     default Stream<DataVectorElement<K>> streamElements() {
         return streamKeys().map(key -> DataVectorElement.of(key, getElement(key)));
+    }
+
+    /**
+     * Returns a DoubleSeries with the same elements as this view (or this view
+     * itself, if it is a DoubleSeries).
+     *
+     * @return a DoubleSeries with the same elements as this view.
+     */
+    default DoubleSeries<K> toSeries(Class<K> keyClass) {
+        if (this instanceof DoubleSeries)
+            return (DoubleSeries<K>) this;
+        else
+            return DoubleSeries.copyOf(keyClass, this);
     }
 }

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/MapDataVector.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/MapDataVector.java
@@ -75,4 +75,9 @@ final class MapDataVector<K> implements DataVector<K> {
     public DoubleStream streamValues() {
         return map.keySet().stream().mapToDouble(map::get);
     }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
 }

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/MapDataVector.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/MapDataVector.java
@@ -30,13 +30,14 @@ import lombok.NonNull;
  * @author Scott Shaffer
  */
 final class MapDataVector<K> implements DataVector<K> {
-    @NonNull private final Map<K, Double> map;
+    @NonNull
+    private final Map<K, Double> map;
 
     MapDataVector() {
         this(new HashMap<>());
     }
 
-    MapDataVector(Map<K, Double> map) {
+    MapDataVector(@NonNull Map<K, Double> map) {
         this.map = map;
     }
 

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/MapDataVector.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/vector/MapDataVector.java
@@ -67,6 +67,11 @@ final class MapDataVector<K> implements DataVector<K> {
     }
 
     @Override
+    public void setElements(Stream<DataVectorElement<K>> elements) {
+        elements.sequential().forEach(this::setElement);
+    }
+
+    @Override
     public Stream<K> streamKeys() {
         return map.keySet().stream();
     }

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
@@ -101,6 +101,11 @@ public class DataPipelineTest extends NumericTestBase {
     }
 
     @Test
+    public void testExp() {
+        assertPipeline1(DataPipeline.exp, 0.1353353, 2.7182818, NA, 20.0855369, 0.6065307);
+    }
+
+    @Test
     public void testFlip() {
         assertPipeline1(DataPipeline.flip, 2.0, -1.0, NA, -3.0, 0.5);
     }
@@ -111,6 +116,11 @@ public class DataPipelineTest extends NumericTestBase {
     }
 
     @Test
+    public void testInvert() {
+        assertPipeline1(DataPipeline.invert, -0.5, 1.0, NA, 0.3333333, -2.0);
+    }
+
+    @Test
     public void testLog() {
         assertPipeline2(DataPipeline.log, 0.6931472, 0.0, NA, 1.0986123, -0.6931472);
     }
@@ -118,6 +128,11 @@ public class DataPipelineTest extends NumericTestBase {
     @Test
     public void testMultiply() {
         assertPipeline1(DataPipeline.multiply(2.0), -4.0, 2.0, NA, 6.0, -1.0);
+    }
+
+    @Test
+    public void testPow() {
+        assertPipeline1(DataPipeline.pow(3.0), -8.0, 1.0, NA, 27.0, -0.125);
     }
 
     @Test
@@ -135,6 +150,11 @@ public class DataPipelineTest extends NumericTestBase {
     @Test
     public void testSqrt() {
         assertPipeline2(DataPipeline.sqrt,  1.4142136, 1.0, NA, 1.7320508, 0.7071068);
+    }
+
+    @Test
+    public void testSquare() {
+        assertPipeline1(DataPipeline.square, 4.0, 1.0, NA, 9.0, 0.25);
     }
 
     @Test

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
@@ -121,6 +121,11 @@ public class DataPipelineTest extends NumericTestBase {
     }
 
     @Test
+    public void testLever() {
+        assertPipeline1(DataPipeline.lever(2.0), -0.6153846, 0.3076923, NA, 0.9230769, -0.1538462);
+    }
+
+    @Test
     public void testLog() {
         assertPipeline2(DataPipeline.log, 0.6931472, 0.0, NA, 1.0986123, -0.6931472);
     }
@@ -128,6 +133,11 @@ public class DataPipelineTest extends NumericTestBase {
     @Test
     public void testMultiply() {
         assertPipeline1(DataPipeline.multiply(2.0), -4.0, 2.0, NA, 6.0, -1.0);
+    }
+
+    @Test
+    public void testNormalize() {
+        assertPipeline1(DataPipeline.normalize, -0.5298129, 0.2649065, NA, 0.7947194, -0.1324532);
     }
 
     @Test

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import java.util.Map;
+import java.util.Random;
+
+import com.d3x.morpheus.stats.Max;
+import com.d3x.morpheus.stats.Min;
+import com.d3x.morpheus.testng.NumericTestBase;
+import com.d3x.morpheus.util.DoubleComparator;
+import com.d3x.morpheus.vector.DataVector;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class DataPipelineTest extends NumericTestBase {
+    private static final double NA = Double.NaN;
+    private static final DoubleComparator comparator = DoubleComparator.fixed(0.000001);
+
+    private static final DataVector<String> vector1 =
+            DataVector.of(Map.of(
+                    "A", -2.0,
+                    "B",  1.0,
+                    "C",   NA,
+                    "D",  3.0,
+                    "E", -0.5));
+
+    private static final DataVector<String> vector2 =
+            DataVector.of(Map.of(
+                    "A", 2.0,
+                    "B", 1.0,
+                    "C",  NA,
+                    "D", 3.0,
+                    "E", 0.5));
+
+    private void assertPipeline(DataPipeline pipeline, DataVector<String> vector, double... expectedValues) {
+        DataVector<String> actualVector = pipeline.apply(DataVector.copy(vector));
+        DataVector<String> expectedVector =
+                DataVector.of(Map.of(
+                        "A", expectedValues[0],
+                        "B", expectedValues[1],
+                        "C", expectedValues[2],
+                        "D", expectedValues[3],
+                        "E", expectedValues[4]));
+
+        assertTrue(actualVector.equalsView(expectedVector, comparator));
+    }
+
+    private void assertPipeline1(DataPipeline pipeline, double... expectedValues) {
+        assertPipeline(pipeline, vector1, expectedValues);
+    }
+
+    private void assertPipeline2(DataPipeline pipeline, double... expectedValues) {
+        assertPipeline(pipeline, vector2, expectedValues);
+    }
+
+    @Test
+    public void testAbs() {
+        assertPipeline1(DataPipeline.abs, 2.0, 1.0, NA, 3.0, 0.5);
+    }
+    
+    @Test
+    public void testAdd() {
+        assertPipeline1(DataPipeline.add(2.5), 0.5, 3.5, NA, 5.5, 2.0);
+    }
+
+    @Test
+    public void testBound() {
+        assertPipeline1(DataPipeline.bound(-1.75, 1.5), -1.75, 1.0, NA, 1.5, -0.5);
+    }
+
+    @Test
+    public void testComposite() {
+        // Order matters...
+        assertPipeline1(DataPipeline.composite(DataPipeline.add(0.1), DataPipeline.abs), 1.9, 1.1, NA, 3.1, 0.4);
+        assertPipeline1(DataPipeline.composite(DataPipeline.abs, DataPipeline.add(0.1)), 2.1, 1.1, NA, 3.1, 0.6);
+    }
+
+    @Test
+    public void testDivide() {
+        assertPipeline1(DataPipeline.divide(2.0), -1.0, 0.5, NA, 1.5, -0.25);
+    }
+
+    @Test
+    public void testDemean() {
+        assertPipeline1(DataPipeline.demean, -2.375, 0.625, NA, 2.625, -0.875);
+    }
+
+    @Test
+    public void testFlip() {
+        assertPipeline1(DataPipeline.flip, 2.0, -1.0, NA, -3.0, 0.5);
+    }
+
+    @Test
+    public void testIdentity() {
+        assertPipeline1(DataPipeline.identity, -2.0, 1.0, NA, 3.0, -0.5);
+    }
+
+    @Test
+    public void testLog() {
+        assertPipeline2(DataPipeline.log, 0.6931472, 0.0, NA, 1.0986123, -0.6931472);
+    }
+
+    @Test
+    public void testMultiply() {
+        assertPipeline1(DataPipeline.multiply(2.0), -4.0, 2.0, NA, 6.0, -1.0);
+    }
+
+    @Test
+    public void testReplaceNaN() {
+        assertPipeline1(DataPipeline.replaceNaN(8.8), -2.0, 1.0, 8.8, 3.0, -0.5);
+    }
+
+    @Test
+    public void testSign() {
+        // The IEEE standard declares that Double.NaN is greater than all other
+        // floating point values, including positive infinity, so its sign is 1.
+        assertPipeline1(DataPipeline.sign, -1.0, 1.0, 1.0, 1.0, -1.0);
+    }
+
+    @Test
+    public void testSqrt() {
+        assertPipeline2(DataPipeline.sqrt,  1.4142136, 1.0, NA, 1.7320508, 0.7071068);
+    }
+
+    @Test
+    public void testStandardize() {
+        assertPipeline1(DataPipeline.standardize, -1.1118909, 0.2926029, NA, 1.2289320, -0.4096440);
+    }
+
+    @Test
+    public void testSubtract() {
+        assertPipeline1(DataPipeline.subtract(2.4), -4.4, -1.4, NA, 0.6, -2.9);
+    }
+
+    @Test
+    public void testTrim() {
+        Random random = new Random(20210505);
+        DataVector<Integer> vector = DataVector.create();
+
+        for (int key = 0; key < 100000; ++key)
+            vector.setElement(key, 2.0 * random.nextDouble());
+
+        DataPipeline.trim(0.05).apply(vector);
+
+        double min = new Min().compute(vector);
+        double max = new Max().compute(vector);
+
+        assertEquals(min, 0.10, 0.01);
+        assertEquals(max, 1.90, 0.01);
+    }
+}

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/DataPipelineTest.java
@@ -15,9 +15,11 @@
  */
 package com.d3x.morpheus.pipeline;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import com.d3x.morpheus.frame.DataFrame;
 import com.d3x.morpheus.stats.Max;
 import com.d3x.morpheus.stats.Min;
 import com.d3x.morpheus.testng.NumericTestBase;
@@ -34,16 +36,16 @@ public class DataPipelineTest extends NumericTestBase {
     private static final DataVector<String> vector1 =
             DataVector.of(Map.of(
                     "A", -2.0,
-                    "B",  1.0,
-                    "C",   NA,
-                    "D",  3.0,
+                    "B", 1.0,
+                    "C", NA,
+                    "D", 3.0,
                     "E", -0.5));
 
     private static final DataVector<String> vector2 =
             DataVector.of(Map.of(
                     "A", 2.0,
                     "B", 1.0,
-                    "C",  NA,
+                    "C", NA,
                     "D", 3.0,
                     "E", 0.5));
 
@@ -72,7 +74,7 @@ public class DataPipelineTest extends NumericTestBase {
     public void testAbs() {
         assertPipeline1(DataPipeline.abs, 2.0, 1.0, NA, 3.0, 0.5);
     }
-    
+
     @Test
     public void testAdd() {
         assertPipeline1(DataPipeline.add(2.5), 0.5, 3.5, NA, 5.5, 2.0);
@@ -159,7 +161,7 @@ public class DataPipelineTest extends NumericTestBase {
 
     @Test
     public void testSqrt() {
-        assertPipeline2(DataPipeline.sqrt,  1.4142136, 1.0, NA, 1.7320508, 0.7071068);
+        assertPipeline2(DataPipeline.sqrt, 1.4142136, 1.0, NA, 1.7320508, 0.7071068);
     }
 
     @Test
@@ -192,5 +194,46 @@ public class DataPipelineTest extends NumericTestBase {
 
         assertEquals(min, 0.10, 0.01);
         assertEquals(max, 1.90, 0.01);
+    }
+
+    private static DataFrame<String, String> makeFrame() {
+        DataFrame<String, String> frame =
+                DataFrame.ofDoubles(List.of("R1", "R2"), List.of("C1", "C2", "C3"));
+
+        frame.setDoubleAt(0, 0, 1.0);
+        frame.setDoubleAt(0, 1, 2.0);
+        frame.setDoubleAt(0, 2, 3.0);
+        frame.setDoubleAt(1, 0, 10.0);
+        frame.setDoubleAt(1, 1, 20.0);
+        frame.setDoubleAt(1, 2, 30.0);
+
+        return frame;
+    }
+
+    @Test
+    public void testDataFrame() {
+        DataFrame<String, String> frame1 = makeFrame();
+        DataPipeline.demean.apply(frame1, 1);
+
+        assertEquals(frame1.listRowKeys(), List.of("R1", "R2"));
+        assertEquals(frame1.listColumnKeys(), List.of("C1", "C2", "C3"));
+        assertTrue(DoubleComparator.DEFAULT.equals(
+                frame1.getDoubleMatrix(),
+                new double[][] {
+                        {  -1.0, 0.0,  1.0 },
+                        { -10.0, 0.0, 10.0 }
+                }));
+
+        DataFrame<String, String> frame2 = makeFrame();
+        DataPipeline.demean.apply(frame2, 2);
+
+        assertEquals(frame2.listRowKeys(), List.of("R1", "R2"));
+        assertEquals(frame2.listColumnKeys(), List.of("C1", "C2", "C3"));
+        assertTrue(DoubleComparator.DEFAULT.equals(
+                frame2.getDoubleMatrix(),
+                new double[][] {
+                        { -4.5, -9.0, -13.5 },
+                        {  4.5,  9.0,  13.5 }
+                }));
     }
 }

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
@@ -24,13 +24,11 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class PipelineScannerTest {
-    private final PipelineFactory factory;
     private final DoubleSeries<Integer> series;
     private static final int SERIES_LENGTH = 1000;
 
     private PipelineScannerTest() {
         this.series = createSeries();
-        this.factory = new PipelineFactory();
     }
 
     private DoubleSeries<Integer> createSeries() {
@@ -44,7 +42,7 @@ public class PipelineScannerTest {
     }
 
     private void assertScanned(String source, DataPipeline expected) {
-        DataPipeline actual = PipelineScanner.scan(source, factory);
+        DataPipeline actual = PipelineScanner.scan(source);
         assertTrue(actual.apply(Integer.class, series).equalsSeries(expected.apply(Integer.class, series)));
     }
 
@@ -83,6 +81,11 @@ public class PipelineScannerTest {
     }
 
     @Test
+    public void testExp() {
+        assertScanned("exp()", DataPipeline.exp);
+    }
+
+    @Test
     public void testFlip() {
         assertScanned("flip()", DataPipeline.flip);
     }
@@ -90,6 +93,11 @@ public class PipelineScannerTest {
     @Test
     public void testIdentity() {
         assertScanned("identity()", DataPipeline.identity);
+    }
+
+    @Test
+    public void testInvert() {
+        assertScanned("invert()", DataPipeline.invert);
     }
 
     @Test
@@ -101,6 +109,11 @@ public class PipelineScannerTest {
     public void testMultiply() {
         assertScanned("multiply(5)", DataPipeline.multiply(5));
         assertScanned("multiply(7.7)", DataPipeline.multiply(7.7));
+    }
+
+    @Test
+    public void testPow() {
+        assertScanned("pow(1.23)", DataPipeline.pow(1.23));
     }
 
     @Test
@@ -117,6 +130,11 @@ public class PipelineScannerTest {
     @Test
     public void testSqrt() {
         assertScanned("sqrt()", DataPipeline.sqrt);
+    }
+
+    @Test
+    public void testSquare() {
+        assertScanned("square()", DataPipeline.square);
     }
 
     @Test

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2014-2021 D3X Systems - All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.d3x.morpheus.pipeline;
+
+import java.util.Random;
+
+import com.d3x.morpheus.series.DoubleSeries;
+import com.d3x.morpheus.series.DoubleSeriesBuilder;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class PipelineScannerTest {
+    private final PipelineFactory factory;
+    private final DoubleSeries<Integer> series;
+    private static final int SERIES_LENGTH = 1000;
+
+    private PipelineScannerTest() {
+        this.series = createSeries();
+        this.factory = new PipelineFactory();
+    }
+
+    private DoubleSeries<Integer> createSeries() {
+        Random random = new Random(20210505);
+        DoubleSeriesBuilder<Integer> builder = DoubleSeries.builder(Integer.class);
+
+        for (int index = 0; index < SERIES_LENGTH; ++index)
+            builder.plusDouble(index, 1.0 + 10.0 * random.nextDouble());
+
+        return builder.build();
+    }
+
+    private void assertScanned(String source, DataPipeline expected) {
+        DataPipeline actual = PipelineScanner.scan(source, factory);
+        assertTrue(actual.apply(Integer.class, series).equalsSeries(expected.apply(Integer.class, series)));
+    }
+
+    @Test
+    public void testAbs() {
+        assertScanned("abs()", DataPipeline.abs);
+    }
+    
+    @Test
+    public void testAdd() {
+        assertScanned("add(3)", DataPipeline.add(3.0));
+        assertScanned("add(1.23)", DataPipeline.add(1.23));
+    }
+
+    @Test
+    public void testBound() {
+        assertScanned("bound(3, 8)", DataPipeline.bound(3.0, 8.0));
+        assertScanned("bound(3.45, 7.89)", DataPipeline.bound(3.45, 7.89));
+    }
+
+    @Test
+    public void testComposite() {
+        assertScanned("add(10.0), sqrt()", DataPipeline.composite(DataPipeline.add(10.0), DataPipeline.sqrt));
+        assertScanned("sqrt(), add(10.0)", DataPipeline.composite(DataPipeline.sqrt, DataPipeline.add(10.0)));
+    }
+
+    @Test
+    public void testDivide() {
+        assertScanned("divide(5)", DataPipeline.divide(5));
+        assertScanned("divide(7.7)", DataPipeline.divide(7.7));
+    }
+
+    @Test
+    public void testDemean() {
+        assertScanned("demean()", DataPipeline.demean);
+    }
+
+    @Test
+    public void testFlip() {
+        assertScanned("flip()", DataPipeline.flip);
+    }
+
+    @Test
+    public void testIdentity() {
+        assertScanned("identity()", DataPipeline.identity);
+    }
+
+    @Test
+    public void testLog() {
+        assertScanned("log()", DataPipeline.log);
+    }
+
+    @Test
+    public void testMultiply() {
+        assertScanned("multiply(5)", DataPipeline.multiply(5));
+        assertScanned("multiply(7.7)", DataPipeline.multiply(7.7));
+    }
+
+    @Test
+    public void testReplaceNaN() {
+        assertScanned("replaceNaN(5)", DataPipeline.replaceNaN(5));
+        assertScanned("replaceNaN(7.7)", DataPipeline.replaceNaN(7.7));
+    }
+
+    @Test
+    public void testSign() {
+        assertScanned("sign()", DataPipeline.sign);
+    }
+
+    @Test
+    public void testSqrt() {
+        assertScanned("sqrt()", DataPipeline.sqrt);
+    }
+
+    @Test
+    public void testStandardize() {
+        assertScanned("standardize()", DataPipeline.standardize);
+    }
+
+    @Test
+    public void testSubtract() {
+        assertScanned("subtract(5)", DataPipeline.subtract(5));
+        assertScanned("subtract(7.7)", DataPipeline.subtract(7.7));
+    }
+
+    @Test
+    public void testTrim() {
+        assertScanned("trim(0.05)", DataPipeline.trim(0.05));
+    }
+}

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
@@ -21,8 +21,6 @@ import com.d3x.morpheus.series.DoubleSeries;
 import com.d3x.morpheus.series.DoubleSeriesBuilder;
 
 import org.testng.annotations.Test;
-import org.yaml.snakeyaml.parser.ParserImpl;
-
 import static org.testng.Assert.*;
 
 public class PipelineScannerTest {

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
@@ -101,6 +101,12 @@ public class PipelineScannerTest {
     }
 
     @Test
+    public void testLever() {
+        assertScanned("lever(1.0)", DataPipeline.lever(1.0));
+        assertScanned("lever(4.5)", DataPipeline.lever(4.5));
+    }
+
+    @Test
     public void testLog() {
         assertScanned("log()", DataPipeline.log);
     }
@@ -109,6 +115,11 @@ public class PipelineScannerTest {
     public void testMultiply() {
         assertScanned("multiply(5)", DataPipeline.multiply(5));
         assertScanned("multiply(7.7)", DataPipeline.multiply(7.7));
+    }
+
+    @Test
+    public void testNormalize() {
+        assertScanned("normalize()", DataPipeline.normalize);
     }
 
     @Test

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/pipeline/PipelineScannerTest.java
@@ -21,6 +21,8 @@ import com.d3x.morpheus.series.DoubleSeries;
 import com.d3x.morpheus.series.DoubleSeriesBuilder;
 
 import org.testng.annotations.Test;
+import org.yaml.snakeyaml.parser.ParserImpl;
+
 import static org.testng.Assert.*;
 
 public class PipelineScannerTest {
@@ -44,6 +46,11 @@ public class PipelineScannerTest {
     private void assertScanned(String source, DataPipeline expected) {
         DataPipeline actual = PipelineScanner.scan(source);
         assertTrue(actual.apply(Integer.class, series).equalsSeries(expected.apply(Integer.class, series)));
+
+        // The encoded pipeline might not match exactly to the source string
+        // because of the argument formatting: add(3) is encoded as add(3.0)
+        DataPipeline decoded = PipelineScanner.scan(expected.encode());
+        assertTrue(decoded.apply(Integer.class, series).equalsSeries(expected.apply(Integer.class, series)));
     }
 
     @Test

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.d3x.morpheus.frame.DataFrame;
 
@@ -77,6 +78,14 @@ public class DataVectorTest {
         map.put("C", 3.0);
 
         runTest(DataVector.of(map));
+    }
+
+    @Test
+    public void testCollect() {
+        runTest(DataVector.collect(Stream.of(
+                DataVectorElement.of("A", 1.0),
+                DataVectorElement.of("B", 2.0),
+                DataVectorElement.of("C", 3.0))));
     }
 }
 

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorTest.java
@@ -87,5 +87,25 @@ public class DataVectorTest {
                 DataVectorElement.of("B", 2.0),
                 DataVectorElement.of("C", 3.0))));
     }
+
+    @Test
+    public void testSetElements() {
+        DataVector<String> v1 = DataVector.create();
+        DataVector<String> v2 = DataVector.create();
+        DataVector<String> v3 = DataVector.create();
+
+        v1.setElement("A", 1.0);
+        v1.setElement("B", 2.0);
+
+        v2.setElement("B", 3.0);
+        v2.setElement("C", 4.0);
+
+        v3.setElement("A", 1.0);
+        v3.setElement("B", 3.0);
+        v3.setElement("C", 4.0);
+
+        v1.setElements(v2);
+        assertTrue(v1.equalsView(v3));
+    }
 }
 

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorViewTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorViewTest.java
@@ -114,5 +114,15 @@ public class DataVectorViewTest {
     public void testRequireElementPresent() {
         baseView.requireElement("A");
     }
+
+    @Test
+    public void testToSeries() {
+        DataVectorView<String> view1 = DataVector.of(Map.of("A", 1.0, "B", 2.0, "C", 3.0));
+        DataVectorView<String> view2 = view1.toSeries(String.class);
+
+        assertSame(baseView.toSeries(String.class), baseView);
+        assertNotSame(view1, view2);
+        assertTrue(view1.equalsView(view2));
+    }
 }
 

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorViewTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/vector/DataVectorViewTest.java
@@ -23,10 +23,11 @@ import java.util.Set;
 import com.d3x.morpheus.frame.DataFrame;
 import com.d3x.morpheus.series.DoubleSeries;
 
+import com.d3x.morpheus.testng.NumericTestBase;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
-public class DataVectorViewTest {
+public class DataVectorViewTest extends NumericTestBase {
     private static final double TOLERANCE = 1.0E-12;
 
     private static final List<String> keyList = List.of("A", "B", "C");
@@ -70,6 +71,18 @@ public class DataVectorViewTest {
     @Test
     public void testMap() {
         runTest(DataVectorView.of(Map.of("A", 1.0, "B", 2.0, "C", 3.0)));
+    }
+
+    @Test
+    public void testNorm1() {
+        DoubleSeries<String> vector = DoubleSeries.build(String.class, List.of("A", "B", "C"), List.of(1.0, -2.0, 3.0));
+        assertDouble(vector.norm1(), 6.0);
+    }
+
+    @Test
+    public void testNorm2() {
+        DoubleSeries<String> vector = DoubleSeries.build(String.class, List.of("A", "B", "C"), List.of(1.0, -2.0, 3.0));
+        assertDouble(baseView.norm2(), Math.sqrt(14.0));
     }
 
     @Test


### PR DESCRIPTION
Adding pre-defined vector transformations that can be used as part of the QuantHub alpha-builder module. Proprietary pipelines, like ones that generate implied alphas or characteristic portfolios, will be implemented in QuantHub itself.