### PR TITLE
Remap the keys of a DataFrame into other classes

### DIFF
--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/frame/DataFrame.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/frame/DataFrame.java
@@ -443,19 +443,9 @@ public interface DataFrame<R,C> extends DataFrameAccess<R,C>, DataFrameOperation
      */
     default <R2, C2> DataFrame<R2, C2> remapKeys(Function<R, R2> rowMapper,
                                                  Function<C, C2> colMapper) {
-        // Since we use ordinal indexing, ensure that the key streams are sequential...
-        DataFrame<R, C> source = this.sequential();
-
-        List<R2> rowKeys2 = source.rows().keys().map(rowMapper).collect(Collectors.toList());
-        List<C2> colKeys2 = source.cols().keys().map(colMapper).collect(Collectors.toList());
-        Class<?> dataType = source.isEmpty() ? Double.class : source.getValueAt(0, 0).getClass();
-        DataFrame<R2, C2> remapped = DataFrame.of(rowKeys2, colKeys2, dataType);
-
-        for (int row = 0; row < source.nrow(); ++row)
-            for (int col = 0; col < source.ncol(); ++col)
-                remapped.setValueAt(row, col, source.getValueAt(row, col));
-
-        return remapped;
+        return sequential()
+                .rows().mapKeys(row -> rowMapper.apply(row.key()))
+                .cols().mapKeys(col -> colMapper.apply(col.key()));
     }
 
     /**

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/frame/DataFrameTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/frame/DataFrameTest.java
@@ -15,7 +15,10 @@
  */
 package com.d3x.morpheus.frame;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import com.d3x.morpheus.matrix.D3xMatrix;
 import com.d3x.morpheus.vector.D3xVector;
@@ -308,5 +311,42 @@ public class DataFrameTest extends DataFrameTestBase {
         assertTrue(D3xMatrix.wrap(sub3.getDoubleMatrix()).equalsMatrix(D3xMatrix.byrow(2, 2,
                 23.0, 21.0,
                 33.0, 31.0)));
+    }
+
+    @Test
+    public void testRemapFrame() {
+        DataFrame<Integer, LocalDate> frame1 = createFrame(12000, 200);
+
+        long start = System.currentTimeMillis();
+        DataFrame<String, String> frame2 = frame1.remapKeys(Object::toString, LocalDate::toString);
+        DataFrame<Integer, LocalDate> frame3 = frame2.remapKeys(Integer::valueOf, LocalDate::parse);
+        System.out.println(System.currentTimeMillis() - start);
+
+        assertEquals(frame3.listRowKeys(), frame1.listRowKeys());
+        assertEquals(frame3.listColumnKeys(), frame1.listColumnKeys());
+
+        for (int row = 0; row < frame1.nrow(); ++row)
+            for (int col = 0; col < frame1.ncol(); ++col)
+                assertEquals(frame3.getIntAt(row, col), frame1.getIntAt(row, col));
+    }
+
+    private static DataFrame<Integer, LocalDate> createFrame(int nrow, int ncol) {
+        Random random = new Random(20210512);
+        List<Integer> rowKeys = new ArrayList<>();
+        List<LocalDate> colKeys = new ArrayList<>();
+
+        for (int row = 0; row < nrow; ++row)
+            rowKeys.add(row);
+
+        for (int col = 0; col < ncol; ++col)
+            colKeys.add(LocalDate.ofYearDay(2021, 1 + col));
+
+        DataFrame<Integer, LocalDate> frame = DataFrame.ofInts(rowKeys, colKeys);
+
+        for (int row = 0; row < nrow; ++row)
+            for (int col = 0; col < ncol; ++col)
+                frame.setIntAt(row, col, random.nextInt(1000));
+
+        return frame;
     }
 }

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/frame/DataFrameTest.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/frame/DataFrameTest.java
@@ -317,10 +317,8 @@ public class DataFrameTest extends DataFrameTestBase {
     public void testRemapFrame() {
         DataFrame<Integer, LocalDate> frame1 = createFrame(12000, 200);
 
-        long start = System.currentTimeMillis();
         DataFrame<String, String> frame2 = frame1.remapKeys(Object::toString, LocalDate::toString);
         DataFrame<Integer, LocalDate> frame3 = frame2.remapKeys(Integer::valueOf, LocalDate::parse);
-        System.out.println(System.currentTimeMillis() - start);
 
         assertEquals(frame3.listRowKeys(), frame1.listRowKeys());
         assertEquals(frame3.listColumnKeys(), frame1.listColumnKeys());


### PR DESCRIPTION
Moving the DataFrame key mapping to Morpheus, which seems the appropriate location.