### PR TITLE
fix: max calculation for negative values

### DIFF
--- a/d3x-morpheus-core/pom.xml
+++ b/d3x-morpheus-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.d3xsystems</groupId>
         <artifactId>d3x-morpheus</artifactId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
 
     <name>d3x-morpheus-core</name>

--- a/d3x-morpheus-core/src/main/java/com/d3x/morpheus/stats/Max.java
+++ b/d3x-morpheus-core/src/main/java/com/d3x/morpheus/stats/Max.java
@@ -15,7 +15,6 @@
  */
 package com.d3x.morpheus.stats;
 
-import com.d3x.morpheus.vector.D3xVector;
 
 /**
  * A Statistic implementation that supports incremental calculation of a sample max
@@ -27,7 +26,7 @@ import com.d3x.morpheus.vector.D3xVector;
 public class Max implements Statistic1 {
 
     private long n;
-    private double max = Double.MIN_VALUE;
+    private double max = Double.NEGATIVE_INFINITY;
 
     /**
      * Constructor
@@ -70,7 +69,7 @@ public class Max implements Statistic1 {
     @Override
     public Statistic1 reset() {
         this.n = 0;
-        this.max = Double.MIN_VALUE;
+        this.max = Double.NEGATIVE_INFINITY;
         return this;
     }
 }

--- a/d3x-morpheus-core/src/test/java/com/d3x/morpheus/stats/Statistic1Test.java
+++ b/d3x-morpheus-core/src/test/java/com/d3x/morpheus/stats/Statistic1Test.java
@@ -29,6 +29,7 @@ public class Statistic1Test {
     private static final D3xVectorView vec2 = D3xVectorView.of(1.0);
     private static final D3xVectorView vec3 = D3xVectorView.of(1.0, 2.0, 3.0, 4.0);
     private static final D3xVectorView vec4 = D3xVectorView.of(1.0, -4.0, 33.0, 4.0);
+    private static final D3xVectorView vec5 = D3xVectorView.of(-0.1, -4.0, -0.33, -4.0);
 
     private static final double TOLERANCE = 1.0E-12;
 
@@ -38,6 +39,7 @@ public class Statistic1Test {
         assertEquals(max.compute(vec2), 1.0, TOLERANCE);
         assertEquals(max.compute(vec3), 4.0, TOLERANCE);
         assertEquals(max.compute(vec4), 33.0, TOLERANCE);
+        assertEquals(max.compute(vec5), -0.1, TOLERANCE);
     }
 
     @Test
@@ -46,6 +48,7 @@ public class Statistic1Test {
         assertEquals(min.compute(vec2), 1.0, TOLERANCE);
         assertEquals(min.compute(vec3), 1.0, TOLERANCE);
         assertEquals(min.compute(vec4), -4.0, TOLERANCE);
+        assertEquals(min.compute(vec5), -4.0, TOLERANCE);
 
     }
 
@@ -54,5 +57,6 @@ public class Statistic1Test {
         assertEquals(sum.compute(vec1), 0.0, TOLERANCE);
         assertEquals(sum.compute(vec2), 1.0, TOLERANCE);
         assertEquals(sum.compute(vec3), 10.0, TOLERANCE);
+        assertEquals(sum.compute(vec5), -8.43, TOLERANCE);
     }
 }

--- a/d3x-morpheus-excel/pom.xml
+++ b/d3x-morpheus-excel/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.d3xsystems</groupId>
         <artifactId>d3x-morpheus</artifactId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
 
     <name>d3x-morpheus-excel</name>

--- a/d3x-morpheus-guava/pom.xml
+++ b/d3x-morpheus-guava/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>d3x-morpheus</artifactId>
         <groupId>com.d3xsystems</groupId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.d3xsystems</groupId>
             <artifactId>d3x-morpheus-core</artifactId>
-            <version>1.0.46</version>
+            <version>1.0.47</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/d3x-morpheus-json/pom.xml
+++ b/d3x-morpheus-json/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.d3xsystems</groupId>
         <artifactId>d3x-morpheus</artifactId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
 
     <name>d3x-morpheus-json</name>

--- a/d3x-morpheus-quandl/pom.xml
+++ b/d3x-morpheus-quandl/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.d3xsystems</groupId>
         <artifactId>d3x-morpheus</artifactId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
 
     <name>d3x-morpheus-quandl</name>

--- a/d3x-morpheus-viz/pom.xml
+++ b/d3x-morpheus-viz/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.d3xsystems</groupId>
         <artifactId>d3x-morpheus</artifactId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
 
     <name>d3x-morpheus-viz</name>

--- a/d3x-morpheus-worldbank/pom.xml
+++ b/d3x-morpheus-worldbank/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.d3xsystems</groupId>
         <artifactId>d3x-morpheus</artifactId>
-        <version>1.0.46</version>
+        <version>1.0.47</version>
     </parent>
 
     <name>d3x-morpheus-worldbank</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.d3xsystems</groupId>
     <artifactId>d3x-morpheus</artifactId>
-    <version>1.0.46</version>
+    <version>1.0.47</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Fixes the maximum statistics calculation of `com.d3x.morpheus.stats.Max` for negative values by using `Double.NEGATIVE_INFINITY` as basis for the calculation as mentioned in #90 